### PR TITLE
refactor: update to gradle 8 and make copyfiles compat

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/hypertrace/gradle/ci/tasks/CopyReportsTask.java
+++ b/src/main/java/org/hypertrace/gradle/ci/tasks/CopyReportsTask.java
@@ -1,17 +1,14 @@
 package org.hypertrace.gradle.ci.tasks;
 
 import java.io.File;
-import java.util.Collection;
-import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.reporting.Report;
-import org.gradle.api.reporting.ReportContainer;
 import org.gradle.api.reporting.Reporting;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.options.Option;
 
 public class CopyReportsTask extends DefaultTask {
@@ -37,33 +34,30 @@ public class CopyReportsTask extends DefaultTask {
 
   public CopyReportsTask() {
     this.setOutputDir(new File(getProject().getBuildDir(), "collected-reports"));
+    this.dependsOn(this.getReportingTasks(getProject()));
   }
 
   @TaskAction
   public void copyFiles() {
-    this.getReportsForProject(this.getProject())
+    this.getReportingTasks(this.getProject())
+        .getAsMap()
         .forEach(
-            report -> {
-              File targetDirectoryForReport =
-                  new File(this.getNamespacedOutputDir(), report.getName());
+            (reportTaskName, reportTask) -> {
+              File targetDirectoryForReportTask =
+                  new File(this.getNamespacedOutputDir(), reportTaskName);
               this.getProject()
                   .copy(
                       copySpec -> {
-                        copySpec.from(report.getOutputLocation());
-                        copySpec.into(targetDirectoryForReport);
+                        copySpec.from(reportTask);
+                        copySpec.into(targetDirectoryForReportTask);
                       });
             });
   }
 
-  private Collection<Report> getReportsForProject(Project project) {
-    return project.getTasks().matching(task -> task instanceof Reporting).stream()
-        .map(this::castTaskToReporter)
-        .flatMap(reporter -> reporter.getReports().stream())
-        .collect(Collectors.toSet());
-  }
-
-  @SuppressWarnings("unchecked")
-  private Reporting<ReportContainer<Report>> castTaskToReporter(Task task) {
-    return (Reporting<ReportContainer<Report>>) task;
+  private TaskCollection<Task> getReportingTasks(Project project) {
+    return project
+        .getTasks()
+        .matching(
+            task -> task instanceof Reporting && !((Reporting<?>) task).getReports().isEmpty());
   }
 }


### PR DESCRIPTION
## Description
Update copy reports task for gradle 8 support by using different APIs to get report outputs.