### PR TITLE
fix: remove depends on

### DIFF
--- a/src/main/java/org/hypertrace/gradle/ci/tasks/CopyReportsTask.java
+++ b/src/main/java/org/hypertrace/gradle/ci/tasks/CopyReportsTask.java
@@ -34,7 +34,6 @@ public class CopyReportsTask extends DefaultTask {
 
   public CopyReportsTask() {
     this.setOutputDir(new File(getProject().getBuildDir(), "collected-reports"));
-    this.dependsOn(this.getReportingTasks(getProject()));
   }
 
   @TaskAction


### PR DESCRIPTION
## Description
Remove depends on for copy reports task. 

Typically, you want tasks to depend on their inputs. For copyAllReports however, we use it to target different reports at different times, generally by running a task and then running copy to gather any output, no matter where it may be. With the dependency, this meant that we were unintentionally always running all reporting tasks whenever we copied, and thus unable to separate the results.